### PR TITLE
Changes to cli.rb to make it work and readme to keep it up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Installation
 3. Give the file the following information:
 
 ```
-url: "http://whatever"
-username: "username"
-password: "password"
+url: 			"http://my-nexus-server/nexus/"
+repository:		"my-repository-id"
+username: 		"username"
+password: 		"password"
 ```
 
 Usage

--- a/lib/nexus_cli/cli.rb
+++ b/lib/nexus_cli/cli.rb
@@ -1,7 +1,7 @@
 require 'thor'
 
 module NexusCli
-  module Cli
+  module Mixin
     def self.included(base)
       base.send :include, ::Thor::Actions
       base.class_eval do
@@ -35,5 +35,10 @@ module NexusCli
         end
       end
     end
+  end
+end
+module NexusCli
+  class Cli < Thor
+    include NexusCli::Mixin
   end
 end


### PR DESCRIPTION
The cli.rb file was modified to be mixed into other Thor projects.
- Adding back the Cli class definition that extends Thor so the original,
  `nexus_cli <command>` works from using the bin/nexus-cli file.
- Nexus repositories have a repository-id field.
