### PR TITLE
restclient timeout settings for large file uploads

### DIFF
--- a/lib/nexus_cli/nexus_oss_remote.rb
+++ b/lib/nexus_cli/nexus_oss_remote.rb
@@ -14,7 +14,7 @@ module NexusCli
     end
 
     def nexus
-      @nexus ||= RestClient::Resource.new configuration["url"], :user => configuration["username"], :password => configuration["password"]
+      @nexus ||= RestClient::Resource.new configuration["url"], :user => configuration["username"], :password => configuration["password"], :timeout => 1000000, :open_timeout => 1000000
     end
 
     def status


### PR DESCRIPTION
Adding restclient timeout settings for large file uploads (i.e., 4GB file).
