### PR TITLE
Just a minor fix

### DIFF
--- a/lib/nexus_cli/nexus_oss_remote.rb
+++ b/lib/nexus_cli/nexus_oss_remote.rb
@@ -589,6 +589,7 @@ module NexusCli
       params = {:repositories => repositories}
       params[:id] = group_repository_json["data"]["id"]
       params[:name] = group_repository_json["data"]["name"]
+      params[:exposed] = group_repository_json["data"]["exposed"]
       JSON.dump(:data => params)
     end
 


### PR DESCRIPTION
Fix for following behavior: after adding repository to a group, group's attribute 'exposed' is always resetted to 'false'
