### PR TITLE
Support Maven classifier

### DIFF
--- a/data/pom.xml.erb
+++ b/data/pom.xml.erb
@@ -5,6 +5,7 @@
   <groupId><%= group_id %></groupId>
   <artifactId><%= artifact_id %></artifactId>
   <version><%= version %></version>
+  <classifier><%= classifier %></classifier>
   <packaging><%= extension %></packaging>
   <description>POM was created by Sonatype Nexus</description>
 </project>

--- a/lib/nexus_cli/base_remote.rb
+++ b/lib/nexus_cli/base_remote.rb
@@ -25,8 +25,12 @@ module NexusCli
         raise ArtifactMalformedException
       end
       group_id, artifact_id, version, extension = split_artifact
+      if extension.include?('@')
+        split_extension = extension.split('@')
+        classifier, extension = split_extension 
+      end
       version.upcase! if version.casecmp("latest")
-      return group_id, artifact_id, version, extension
+      return group_id, artifact_id, version, extension, classifier
     end
   end
 end

--- a/lib/nexus_cli/mixins/pro/custom_metadata_actions.rb
+++ b/lib/nexus_cli/mixins/pro/custom_metadata_actions.rb
@@ -6,8 +6,9 @@ module NexusCli
     # @param [String] artifact The GAVE string of the artifact
     # @result [String] The resulting custom metadata xml from the get operation
     def get_artifact_custom_info_raw(artifact)
-      group_id, artifact_id, version, extension = parse_artifact_string(artifact)
-      encoded_string = N3Metadata::create_base64_subject(group_id, artifact_id, version, extension)
+      group_id, artifact_id, version, extension, classifier = parse_artifact_string(artifact)
+      encoded_string = N3Metadata::create_base64_subject(group_id, artifact_id, version, extension, classifier)
+      puts encoded_string
       response = nexus.get(nexus_url("service/local/index/custom_metadata/#{configuration['repository']}/#{encoded_string}"))
       case response.status
       when 200

--- a/lib/nexus_cli/n3_metadata.rb
+++ b/lib/nexus_cli/n3_metadata.rb
@@ -21,8 +21,8 @@ module NexusCli
       end
 
       # Creates a custom metadata subject for HTTP requests.
-      def create_base64_subject(group_id, artifact_id, version, extension)
-        return Base64.urlsafe_encode64("urn:maven/artifact##{group_id}:#{artifact_id}:#{version}::#{extension}")
+      def create_base64_subject(group_id, artifact_id, version, extension, classifier)
+        return Base64.urlsafe_encode64("urn:maven/artifact##{group_id}:#{artifact_id}:#{version}:#{classifier}:#{extension}")
       end
 
       # Parses the regular custom metadata xml into a simpler format containing only the custom metadata.

--- a/spec/unit/nexus_cli/oss_remote_spec.rb
+++ b/spec/unit/nexus_cli/oss_remote_spec.rb
@@ -21,6 +21,11 @@ describe NexusCli do
     expect {remote.pull_artifact "com.something:something:1.0.0:tgz", nil}.to raise_error(NexusCli::ArtifactNotFoundException)
   end
 
+  it "gives you errors when you attempt to pull an artifact with classifier and it cannot be found" do
+    HTTPClient.any_instance.stub(:get).and_raise(NexusCli::ArtifactNotFoundException)
+    expect {remote.pull_artifact "com.something:something:1.0.0:x64@tgz", nil}.to raise_error(NexusCli::ArtifactNotFoundException)
+  end
+
   it "gives you errors when you attempt to get an artifact's info and it cannot be found" do
     HTTPClient.any_instance.stub(:get).and_raise(NexusCli::ArtifactNotFoundException)
     expect {remote.get_artifact_info "com.something:something:1.0.0:tgz"}.to raise_error(NexusCli::ArtifactNotFoundException)


### PR DESCRIPTION
This is a first attempt to support Maven classifier in a gradle like syntax

```
com.something:something:1.0.0:x64@tgz
```

where the classifiert part is optional.

What do you think about the syntax?

The pull request is working for Nexus OSS, but I haven't done anything for push or the Pro version. 
