### PR TITLE
License missing from gemspec

### DIFF
--- a/nexus_cli.gemspec
+++ b/nexus_cli.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/RiotGames/nexus_cli"
   s.summary     = %q{A command-line wrapper for making REST calls to Sonatype Nexus.}
   s.description = s.summary
+  s.license     = ["Apache 2.0"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
RubyGems.org doesn't report a license for your gem.  This is because it is not specified in the [gemspec](http://docs.rubygems.org/read/chapter/20#license) of your last release.

via e.g.

```
spec.license = 'MIT'
# or
spec.licenses = ['MIT', 'GPL-2']
```

Including a license in your gemspec is an easy way for rubygems.org and other tools to check how your gem is licensed.  As you can imagine, scanning your repository for a LICENSE file or parsing the README, and then attempting to identify the license or licenses is much more difficult and more error prone. So, even for projects that already specify a license, including a license in your gemspec is a good practice. See, for example, how [rubygems.org uses the gemspec to  display the rails gem license](https://rubygems.org/gems/rails).

There is even a [License Finder gem](https://github.com/pivotal/LicenseFinder) to help companies/individuals ensure all gems they use meet their licensing needs. This tool depends on license information being available in the gemspec.  This is an important enough issue that _even Bundler now generates gems with a default 'MIT' license_.

I hope you'll consider specifying a license in your gemspec. If not, please just close the issue with a nice message. In either case, I'll follow up. Thanks for your time!

Appendix:

If you need help choosing a [license](http://opensource.org/licenses) (sorry, I haven't checked your readme or looked for a license file), GitHub has created a [license picker tool](http://choosealicense.com/).  Code without a license specified defaults to 'All rights reserved'-- denying others all rights to use of the code.
Here's a [list of the license names I've found and their frequencies](https://github.com/bf4/gemproject/blob/master/license_usage.csv)

p.s. In case you're wondering how I found you and why I made this issue, it's because I'm collecting stats on gems (I was originally looking for download data) and decided to collect license metadata,too, and [make issues for gemspecs not specifying a license as a public service :)](https://github.com/bf4/gemproject/issues/1). See the previous link or my [blog post about this project for more information](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/).
