### PR TITLE
Be more restrictive on activesupport

### DIFF
--- a/nexus_cli.gemspec
+++ b/nexus_cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline'
   s.add_dependency 'jsonpath'
   s.add_runtime_dependency 'chozo', '>= 0.6.0'
-  s.add_runtime_dependency 'activesupport', '>= 3.2.0'
+  s.add_runtime_dependency 'activesupport', '~> 3.2.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'aruba', "= 0.5.0"


### PR DESCRIPTION
Apparently some versions of activesupport require Ruby 1.9.3 or greater. At the moment, this is annoying me because of either my Vagrant box or a Chef omnibus installation that uses Ruby 1.9.2.

We should probably be a bit more restrictive in any case on this, rather than defaulting to pulling in the latest and greatest on a fresh Ruby install.
