### PR TITLE
Add thor task for getting an artifact's download URL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .rake_tasks~
 .project

--- a/features/nexus_oss.feature
+++ b/features/nexus_oss.feature
@@ -54,6 +54,14 @@ Feature: Use the Nexus CLI
       """
     And the exit status should be 0
 
+  Scenario: Get an artifact's download URL
+    When I call the nexus "get_artifact_download_url com.test:mytest" command
+    Then the output should contain:
+      """
+      com/test/mytest/1.0.0/mytest-1.0.0.tgz
+      """
+    And the exit status should be 0
+
   @transfer
   Scenario: Transfer an artifact between repositories
     When I call the nexus "transfer com.test:mytest:tgz:1.0.0 releases thirdparty" command

--- a/lib/nexus_cli/tasks.rb
+++ b/lib/nexus_cli/tasks.rb
@@ -433,6 +433,11 @@ module NexusCli
           end
         end
 
+        desc "get_artifact_download_url coordinates", "Gets the Nexus download URL for the given artifact."
+        def get_artifact_download_url(coordinates)
+          say nexus_remote.get_artifact_download_url(coordinates), :green
+        end
+
         private
 
           def nexus_remote

--- a/spec/unit/nexus_cli/oss_remote_spec.rb
+++ b/spec/unit/nexus_cli/oss_remote_spec.rb
@@ -75,4 +75,9 @@ describe NexusCli do
     stub_request(:get, "http://admin:admin123@localhost:8081/nexus/service/local/data_index?a=something&g=com.something").to_return(:status => 200, :body => fake_xml, :headers => {})
     remote.search_for_artifacts("com.something:something").should eq fake_xml
   end
+
+  it "gives you errors when you attempt to get an artifact's download url and it cannot be found" do
+    HTTPClient.any_instance.stub(:get).and_raise(NexusCli::ArtifactNotFoundException)
+    expect {remote.get_artifact_download_url "com.something:something:tgz:1.0.0"}.to raise_error(NexusCli::ArtifactNotFoundException)
+  end
 end


### PR DESCRIPTION
Add thor task for getting an artifact's download URL. The logic is similar to pull_artifact except it just returns the URL rather than following the redirect.
