### PR TITLE
issue #95 - get_repository_info(name) should pass the DEFAULT_ACCEPT_HEADER to nexus.

### DIFF
--- a/lib/nexus_cli/mixins/repository_actions.rb
+++ b/lib/nexus_cli/mixins/repository_actions.rb
@@ -58,7 +58,7 @@ module NexusCli
     # @return [String] A String of XML with information about the desired
     # repository.
     def get_repository_info(name)
-      response = nexus.get(nexus_url("service/local/repositories/#{sanitize_for_id(name)}"))
+      response = nexus.get(nexus_url("service/local/repositories/#{sanitize_for_id(name)}"), :header => DEFAULT_ACCEPT_HEADER)
       case response.status
       when 200
         return response.content


### PR DESCRIPTION
Return JSON when fetching repository info.
