### PR TITLE
Update httpclient dependency

### DIFF
--- a/nexus_cli.gemspec
+++ b/nexus_cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'thor'
-  s.add_dependency 'httpclient', '= 2.2.5'
+  s.add_dependency 'httpclient', '>= 2.2.5'
   s.add_dependency 'extlib'
   s.add_dependency 'json'
   s.add_dependency 'highline'


### PR DESCRIPTION
Use optimistic dependency constraint for httpclient in order to make
nexus_cli work with more recent versions of the httpclient gem.
