### PR TITLE
add proxy repository authentication

### DIFF
--- a/lib/nexus_cli/mixins/repository_actions.rb
+++ b/lib/nexus_cli/mixins/repository_actions.rb
@@ -14,9 +14,9 @@ module NexusCli
     # @param  provider [String] repo provider (maven2 by default)
     # 
     # @return [Boolean] returns true on success
-    def create_repository(name, proxy, url, id, policy, provider)
+    def create_repository(name, proxy, url, id, policy, provider, username, password)
       json = if proxy
-        create_proxy_repository_json(name, url, id, policy, provider)
+        create_proxy_repository_json(name, url, id, policy, provider, username, password)
       else
         create_hosted_repository_json(name, id, policy, provider)
       end
@@ -186,14 +186,14 @@ module NexusCli
       params[:browseable] = true
       params[:indexable] = true
       params[:repoType] = "hosted"
-      params[:repoPolicy] = policy.nil? ? "RELEASE" : ["RELEASE", "SNAPSHOT"].include?(policy) ? policy : "RELEASE" 
-      params[:name] = name
+      params[:repoPolicy] = policy.nil? ? "RELEASE" : ["RELEASE", "SNAPSHOT"].include?(policy) ? policy : "RELEASE"
+      params[:name] = name.nil? ? id : name
       params[:id] = id.nil? ? sanitize_for_id(name) : sanitize_for_id(id)
       params[:format] = "maven2"
       JSON.dump(:data => params)
     end
 
-    def create_proxy_repository_json(name, url, id, policy, provider)
+    def create_proxy_repository_json(name, url, id, policy, provider, username, password)
       params = {:provider => provider.nil? ? "maven2" : provider}
       params[:providerRole] = "org.sonatype.nexus.proxy.repository.Repository"
       params[:exposed] = true
@@ -205,15 +205,20 @@ module NexusCli
       params[:writePolicy] = "READ_ONLY"
       params[:downloadRemoteIndexes] = true
       params[:autoBlockActive] = false
-      params[:name] = name
+      params[:name] = name.nil? ? id : name
       params[:id] = id.nil? ? sanitize_for_id(name) : sanitize_for_id(id)
       params[:remoteStorage] = {:remoteStorageUrl => url.nil? ? "http://change-me.com/" : url}
+      if (username) && (password)
+        params[:remoteStorage] = {:remoteStorageUrl => url.nil? ? "http://change-me.com/" : url, :authentication =>  {"username" => username ,"password" => password}}
+      else
+        params[:remoteStorage] = {:remoteStorageUrl => url.nil? ? "http://change-me.com/" : url}
+      end
       JSON.dump(:data => params)
     end
 
     def create_group_repository_json(name, id, provider)
       params = {:id => id.nil? ? sanitize_for_id(name) : sanitize_for_id(id)}
-      params[:name] = name
+      params[:name] = name.nil? ? id : name
       params[:provider] = provider.nil? ? "maven2" : provider
       params[:exposed] = true
       JSON.dump(:data => params)

--- a/lib/nexus_cli/tasks.rb
+++ b/lib/nexus_cli/tasks.rb
@@ -142,9 +142,15 @@ module NexusCli
         method_option :url,
           :type => :string,
           :desc => "The url of the actual repository for the proxy repository to use."
+        method_option :username,
+          :type => :string,
+          :desc => "The username for the remote proxy repository."
+        method_option :password,
+          :type => :string,
+          :desc => "The password for the remote proxy repository."
         desc "create_repository name", "Creates a new Repository with the provided name."
         def create_repository(name)
-          if nexus_remote.create_repository(name, options[:proxy], options[:url], options[:id], options[:policy], options[:provider])
+          if nexus_remote.create_repository(name, options[:proxy], options[:url], options[:id], options[:policy], options[:provider], options[:username], options[:password])
             say "A new Repository named #{name} has been created.", :blue
           end
         end


### PR DESCRIPTION
replaces #106 - extend create_repository with username and password for proxy repositories.

* it is a breaking change and has to be synced in nexus-cookbook
* use username and password for proxy authentication
* if name is nil build it from id

This is a dependency for https://github.com/RiotGamesCookbooks/nexus-cookbook/pull/103