### PR TITLE
Force Content-Type header when pushing artifact

### DIFF
--- a/lib/nexus_cli/mixins/artifact_actions.rb
+++ b/lib/nexus_cli/mixins/artifact_actions.rb
@@ -55,7 +55,7 @@ module NexusCli
     def push_artifact(coordinates, file)
       artifact = Artifact.new(coordinates)
       put_string = "content/repositories/#{configuration['repository']}/#{artifact.group_id.gsub(".", "/")}/#{artifact.artifact_id.gsub(".", "/")}/#{artifact.version}/#{artifact.file_name}"
-      response = nexus.put(nexus_url(put_string), File.open(file))
+      response = nexus.put(nexus_url(put_string), File.open(file), { 'Content-Type' => '' })
 
       case response.status
       when 201

--- a/spec/unit/nexus_cli/configuration_spec.rb
+++ b/spec/unit/nexus_cli/configuration_spec.rb
@@ -140,7 +140,7 @@ describe NexusCli::Configuration do
     context "when repository has illegal values" do
       let(:repository) { "ILLEGAL VALUE" }
       it "makes it legal" do
-        expect(repository_config.repository).to eq("illegal_value")
+        expect(repository_config.repository).to eq("ILLEGAL_VALUE")
       end
     end
   end


### PR DESCRIPTION
By default httpclient gem will add application/x-www-form-urlencoded as
content-type which nexus seems to dislike when receiving artifact.
It makes nexus decodes the content and usually fails with a 500.

See for related details: https://issues.sonatype.org/browse/NEXUS-6622