### PR TITLE
drop chozo+extlib in configuration parsing (fixes #123)

### DIFF
--- a/lib/nexus_cli/configuration.rb
+++ b/lib/nexus_cli/configuration.rb
@@ -1,5 +1,4 @@
-require 'extlib'
-require 'chozo'
+require 'yaml'
 
 module NexusCli
   class Configuration
@@ -68,28 +67,35 @@ module NexusCli
       self.class.validate!(self)
     end
 
-    include Chozo::VariaModel
+    def valid?
+      errors.empty?
+    end
 
-    attribute :url,
-      type: String,
-      required: true
+    def errors
+      result = Hash.new
+      result[:url] = ["url required"] unless url.is_a?(String) && url.size > 0
+      result[:repository] = ["repository required"] unless repository.is_a?(String) && repository.size > 0
+      result
+    end
 
-    attribute :repository,
-      type: String,
-      required: true,
-      coerce: lambda { |m|
-        m = m.is_a?(String) ? m.gsub(' ', '_') : m
-      }
-
-    attribute :username,
-      type: String
-
-    attribute :password,
-      type: String
+    attr_accessor :url
+    attr_accessor :repository
+    attr_accessor :username
+    attr_accessor :password
 
     def initialize(options)
-      mass_assign(options)
-      self.repository = options[:repository]
+      @url = options[:url]
+      @repository = options[:repository]
+      @username = options[:username]
+      @password = options[:password]
+
+      if @repository.is_a?(String)
+        @repository = @repository.gsub(' ', '_')
+      end
+    end
+
+    def [](attr)
+      self.instance_variable_get('@' + attr.to_s)
     end
   end
 end

--- a/nexus_cli.gemspec
+++ b/nexus_cli.gemspec
@@ -19,11 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'thor'
   s.add_dependency 'httpclient', '~> 2.8.0'
-  s.add_dependency 'extlib'
   s.add_dependency 'json'
   s.add_dependency 'highline'
   s.add_dependency 'jsonpath'
-  s.add_runtime_dependency 'chozo', '>= 0.6.0'
   s.add_runtime_dependency 'activesupport', '~> 3.2.0'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
extlib breaks keywords arguments (issue #123). this PR removes the extlib dependency.
chozo breaks ruby 2.3, it has an incompatible dig method (see [1]). this PR also removes the chozo dependency. 

[1] https://github.com/killbill/killbill/issues/714